### PR TITLE
Add Blake2b hashing algorithm (sodium's generic hash)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -742,6 +742,142 @@ SHA512: 4DBFF86CC2CA1BAE1E16468A05CB9881C97F1753BCE3619034898FAA1AABE429
         955A1BF8EC483D7421FE3C1646613A59ED5441FB0F321389F77F48A879C7B1F1
 ----
 
+== Blake2b Hashing
+
+A given message or data of arbitrary size can be deterministically hashed to a 32-byte or 64-byte value via standard
+Blake2b and varying the output size length accordingly. Chronicle-Salt supports various options for invoking the
+Blake2b hash functions (or generic hash functions as they are called in the Sodium API), as well as a multi-part API
+to support generating a hash for a sequence of messages/data.
+
+=== Blake2b-256 Hash
+
+The Blake2b-256 hash of a message can be obtained using one of the following:
+[source, Java]
+----
+BytesStore Blake2b.hash256( BytesStore message );                    // creates a BytesStore to hold the hash
+BytesStore Blake2b.hash256( BytesStore result, BytesStore message ); // place hash in provided BytesStore
+----
+
+Alternatively, a Blake2b-256 hash can be appended to a given `Bytes` handle:
+[source, Java]
+void Blake2b.append256( Bytes output, BytesStore message );
+
+For example:
+[source, Java]
+----
+    BytesStore message = "example message";
+
+    // Option 1: Create and return the BytesStore
+    BytesStore hash = Blake2b.hash256( message );
+
+    // Option 2: Use an existing BytesStore to hold the result
+    BytesStore hash = ...;
+    Blake2b.hash256( hash, message );
+
+    // Option 3: append the hash to a given Bytes handle
+    Bytes hash256 = Bytes.allocateDirect(Blake2b.HASH_BLAKE2B_256_BYTES));
+    Blake2b.append256(hash256, message);
+----
+
+=== Blake2b-512 Hash
+
+The Blake2b-512 hash of a message can be obtained using one of the following:
+[source, Java]
+----
+BytesStore Blake2b.hash512( BytesStore message );                    // creates a BytesStore to hold the hash
+BytesStore Blake2b.hash512( BytesStore result, BytesStore message ); // place hash in provided BytesStore
+----
+
+Alternatively, a Blake2b-512 hash can be appended to a given `Bytes` handle:
+[source, Java]
+void Blake2b.append512( Bytes output, BytesStore message );
+
+For example:
+[source, Java]
+----
+    BytesStore message = "example message";
+
+    // Option 1: Create and return the BytesStore
+    BytesStore hash = Blake2b.hash512( message );
+
+    // Option 2: Use an existing BytesStore to hold the result
+    BytesStore hash = ...;
+    Blake2b.hash512( hash, message );
+
+    // Option 3: append the hash to a given Bytes handle
+    Bytes hash512 = Bytes.allocateDirect(Blake2b.HASH_BLAKE2B_512_BYTES));
+    Blake2b.append512(hash512, message);
+----
+
+=== Multi-Part Blake2b-256 and Blake2b-512 Hashing
+
+In addition to single-message hashing as described above, it is also possible to generate a single hash for a collection
+of several arbitrarily-sized message parts. Multi-part hashing is provided by the `Blake2b.MultiPart256` and
+`Blake2b.MultiPart512` wrapper classes.
+
+Once a `MultiPart256` or `MultiPart512` message is initialised, individual message parts can be added using:
+[source, Java]
+----
+void Blake2b.MultiPart256.add( BytesStore message );
+void Blake2b.MultiPart512.add( BytesStore message );
+----
+
+The hash for the collection of messages is then obtained as follows:
+[source, Java]
+----
+BytesStore Blake2b.MultiPart256.hash();                   // create a BytesStore to hold the hash
+BytesStore Blake2b.MultiPart256.hash( BytesStore result); // place hash in provided BytesStore
+
+BytesStore Blake2b.MultiPart512.hash();                   // create a BytesStore to hold the hash
+BytesStore Blake2b.MultiPart512.hash( BytesStore result); // place hash in provided BytesStore
+----
+
+Once `hash` has been called the `MultiPart256` or `MultiPart512` object should not be used further without first
+being reset:
+[source, Java]
+----
+void Blake2b.MultiPart256.reset();
+void Blake2b.MultiPart512.reset();
+----
+
+The following is a complete example generating the Blake2b-256 and Blake2b-512 hash of a collection of messages:
+[source, Java]
+----
+BytesStore message1 = NativeBytesStore.from( "abcdefgh");
+BytesStore message2 = NativeBytesStore.from( "ijklmnop");
+BytesStore message3 = NativeBytesStore.from( "qrstuvwxyz");
+
+// Initialise a MultiPart256 wrapper
+Blake2b.MultiPart256 multi256 = new Blake2b.MultiPart256();
+multi256.add( message1 );
+multi256.add( message2 );
+multi256.add( message3 );
+
+// Generate the single Blake2b-256 hash of the set of messages
+BytesStore hash256 = multi256.hash();
+
+// Initialise a MultiPart512 wrapper
+Blake2b.MultiPart512 multi512 = new Blake2b.MultiPart512();
+multi512.add( message1 );
+multi512.add( message2 );
+multi512.add( message3 );
+
+// Generate the single Blake2b-512 hash of the set of messages
+BytesStore hash512 = multi512.hash();
+
+System.out.println("Blake2b 256: " + DatatypeConverter.printHexBinary(hash256.toByteArray()));
+System.out.println("Blake2b 512: " + DatatypeConverter.printHexBinary(hash512.toByteArray()));
+----
+
+The above prints the following, matching the hashes of the full message `abcdefghijklmnopqrstuvwxyz`:
+[source]
+----
+Blake2b-256: 117AD6B940F5E8292C007D9C7E7350CD33CF85B5887E8DA71C7957830F536E7C
+
+Blake2b-512: C68EDE143E416EB7B4AAAE0D8E48E55DD529EAFED10B1DF1A61416953A2B0A56
+             66C761E7D412E6709E31FFE221B7A7A73908CB95A4D120B8B090A87D1FBEDB4C
+----
+
 == Benchmark
 
 The library can be run in parallel to improve throughput

--- a/src/main/java/net/openhft/chronicle/salt/Blake2b.java
+++ b/src/main/java/net/openhft/chronicle/salt/Blake2b.java
@@ -1,0 +1,204 @@
+package net.openhft.chronicle.salt;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.core.Maths;
+
+import static net.openhft.chronicle.salt.Sodium.SIZEOF_CRYPTO_HASH_BLAKE2B_STATE;
+import static net.openhft.chronicle.salt.Sodium.checkValid;
+
+public enum Blake2b {
+    ; // none
+    static final int HASH_BLAKE2B_256_BYTES = 32;
+    static final int HASH_BLAKE2B_512_BYTES = 64;
+
+    /**
+     * Generate Blake2b hash (256 bits) for a given message
+     *
+     * @param message
+     *            - the message to hash
+     * @return - the Blake2b hash
+     */
+    public static BytesStore hash256(BytesStore message) {
+        return hash256(null, message);
+    }
+
+    /**
+     * Generate Blake2b hash (256 bits) for a given message
+     *
+     * @param result
+     *            - the BytesStore to hold the result
+     * @param message
+     *            - the message to hash
+     * @return - the Blake2b hash
+     */
+    public static BytesStore hash256(BytesStore result, BytesStore message) {
+        result = Sodium.Util.setSize(result, HASH_BLAKE2B_256_BYTES);
+        checkValid(Sodium.SODIUM.crypto_generichash(result.addressForWrite(0), HASH_BLAKE2B_256_BYTES,
+                        message.addressForRead(message.readPosition()), Maths.toUInt31(message.readRemaining()), 0L, 0),
+                "couldn't Blake2b");
+        return result;
+    }
+
+    /**
+     * Append the Blake2b hash (256 bits) of a message to a given Bytes handle
+     *
+     * @param hashGeneric
+     *            - the Bytes handle onto which the Blake2b hash is appended
+     * @param message
+     *            - the message to hash
+     */
+    public static void append256(Bytes<?> hashGeneric, BytesStore<?, ?> message) {
+        long wp = hashGeneric.writePosition();
+        hashGeneric.ensureCapacity(wp + HASH_BLAKE2B_256_BYTES);
+        checkValid(Sodium.SODIUM.crypto_generichash(hashGeneric.addressForWrite(wp), HASH_BLAKE2B_256_BYTES,
+                        message.addressForRead(message.readPosition()), Maths.toUInt31(message.readRemaining()), 0L, 0),
+                "couldn't Blake2b");
+        hashGeneric.writeSkip(HASH_BLAKE2B_256_BYTES);
+    }
+
+    /**
+     * Generate Blake2b hash (512 bits) for a given message
+     *
+     * @param message
+     *            - the message to hash
+     * @return - the Blake2b hash
+     */
+    public static BytesStore hash512(BytesStore message) {
+        return hash512(null, message);
+    }
+
+    /**
+     * Generate Blake2b hash (512 bits) for a given message
+     *
+     * @param result
+     *            - the BytesStore to hold the result
+     * @param message
+     *            - the message to hash
+     * @return - the Blake2b hash
+     */
+    public static BytesStore hash512(BytesStore result, BytesStore message) {
+        result = Sodium.Util.setSize(result, HASH_BLAKE2B_512_BYTES);
+        checkValid(Sodium.SODIUM.crypto_generichash(result.addressForWrite(0), HASH_BLAKE2B_512_BYTES,
+                message.addressForRead(message.readPosition()), Maths.toUInt31(message.readRemaining()), 0L, 0),
+                "couldn't Blake2b");
+        return result;
+    }
+
+    /**
+     * Append the Blake2b hash (512 bits) of a message to a given Bytes handle
+     *
+     * @param hashGeneric
+     *            - the Bytes handle onto which the Blake2b hash is appended
+     * @param message
+     *            - the message to hash
+     */
+    public static void append512(Bytes<?> hashGeneric, BytesStore<?, ?> message) {
+        long wp = hashGeneric.writePosition();
+        hashGeneric.ensureCapacity(wp + HASH_BLAKE2B_512_BYTES);
+        checkValid(Sodium.SODIUM.crypto_generichash(hashGeneric.addressForWrite(wp), HASH_BLAKE2B_512_BYTES,
+                message.addressForRead(message.readPosition()), Maths.toUInt31(message.readRemaining()), 0L, 0),
+                "couldn't Blake2b");
+        hashGeneric.writeSkip(HASH_BLAKE2B_512_BYTES);
+    }
+
+     /**
+     * Wrapper for Blake2b signing (256 bits) multi-part messages composed of a sequence of arbitrarily-sized chunks
+     */
+     public static class MultiPart256 {
+
+         public final BytesStore state;
+
+         /**
+         * Initialise a wrapper for a single multi-part message exchange
+         */
+         public MultiPart256() {
+             this.state = Bytes.allocateDirect(SIZEOF_CRYPTO_HASH_BLAKE2B_STATE);
+             ((Bytes) state).readLimit(SIZEOF_CRYPTO_HASH_BLAKE2B_STATE);
+
+             Sodium.SODIUM.crypto_generichash_init(state.addressForRead(0), 0L, 0, HASH_BLAKE2B_256_BYTES);
+         }
+
+         public void reset() {
+             checkValid(Sodium.SODIUM.crypto_generichash_init(state.addressForRead(0), 0L, 0, HASH_BLAKE2B_256_BYTES),
+                     "couldn't reset Blake2b");
+         }
+
+         /**
+         * Add a part to this multi-part hash
+         *
+         * @param message
+         * - the message to add
+         */
+         public void add(BytesStore message) {
+             checkValid(Sodium.SODIUM.crypto_generichash_update(state.addressForRead(0), message.addressForRead(message.readPosition()),
+             message.readRemaining()), "Failed to add to multi-part message");
+         }
+
+         /**
+         * Generate the single hash for the collection of messages
+         *
+         * @return - the single hash
+         */
+         public BytesStore hash() {
+            return hash(null);
+         }
+
+         public BytesStore hash(BytesStore result) {
+             result = Sodium.Util.setSize(result, HASH_BLAKE2B_256_BYTES);
+             checkValid(Sodium.SODIUM.crypto_generichash_final(state.addressForRead(0), result.addressForWrite(0), HASH_BLAKE2B_256_BYTES),
+                     "Multi-part Blake2b failed");
+             return result;
+         }
+     }
+
+    /**
+     * Wrapper for Blake2b signing (512 bits) multi-part messages composed of a sequence of arbitrarily-sized chunks
+     */
+    public static class MultiPart512 {
+
+        public final BytesStore state;
+
+        /**
+         * Initialise a wrapper for a single multi-part message exchange
+         */
+        public MultiPart512() {
+            this.state = Bytes.allocateDirect(SIZEOF_CRYPTO_HASH_BLAKE2B_STATE);
+            ((Bytes) state).readLimit(SIZEOF_CRYPTO_HASH_BLAKE2B_STATE);
+
+            Sodium.SODIUM.crypto_generichash_init(state.addressForRead(0), 0L, 0, HASH_BLAKE2B_512_BYTES);
+        }
+
+        public void reset() {
+            checkValid(Sodium.SODIUM.crypto_generichash_init(state.addressForRead(0), 0L, 0, HASH_BLAKE2B_512_BYTES),
+                    "couldn't reset Blake2b");
+        }
+
+        /**
+         * Add a part to this multi-part hash
+         *
+         * @param message
+         * - the message to add
+         */
+        public void add(BytesStore message) {
+            checkValid(Sodium.SODIUM.crypto_generichash_update(state.addressForRead(0), message.addressForRead(message.readPosition()),
+                    message.readRemaining()), "Failed to add to multi-part message");
+        }
+
+        /**
+         * Generate the single hash for the collection of messages
+         *
+         * @return - the single hash
+         */
+        public BytesStore hash() {
+            return hash(null);
+        }
+
+        public BytesStore hash(BytesStore result) {
+            result = Sodium.Util.setSize(result, HASH_BLAKE2B_512_BYTES);
+            checkValid(Sodium.SODIUM.crypto_generichash_final(state.addressForRead(0), result.addressForWrite(0), HASH_BLAKE2B_512_BYTES),
+                    "Multi-part Blake2b failed");
+            return result;
+        }
+    }
+}

--- a/src/main/java/net/openhft/chronicle/salt/Sodium.java
+++ b/src/main/java/net/openhft/chronicle/salt/Sodium.java
@@ -1,10 +1,12 @@
 package net.openhft.chronicle.salt;
 
+import jnr.ffi.Address;
 import jnr.ffi.LibraryLoader;
 import jnr.ffi.Platform;
 import jnr.ffi.annotations.In;
 import jnr.ffi.annotations.Out;
 import jnr.ffi.byref.LongLongByReference;
+import jnr.ffi.types.caddr_t;
 import jnr.ffi.types.u_int64_t;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesStore;
@@ -28,6 +30,7 @@ public interface Sodium {
 
     int CRYPTO_BOX_CURVE25519XSALSA20POLY1305_PUBLICKEYBYTES = 32;
     int CRYPTO_BOX_CURVE25519XSALSA20POLY1305_SECRETKEYBYTES = 32;
+    int SIZEOF_CRYPTO_HASH_BLAKE2B_STATE = 384;
     int SIZEOF_CRYPTO_HASH_SHA256_STATE = 128; // actual = 104. Add a little headroom
     int SIZEOF_CRYPTO_HASH_SHA512_STATE = 256; // actual = 208. Add a little headroom
     // ---------------------------------------------------------------------
@@ -84,6 +87,16 @@ public interface Sodium {
     /// Easy Boxes
 
     int crypto_scalarmult_curve25519(@In long result, @In long intValue, @In long point);
+
+    // generic (Blake2b) hashes
+    int crypto_generichash(@In @caddr_t long buffer, @In @u_int64_t int out, @In @caddr_t long message, @In @u_int64_t int msgLen,
+                           @In @caddr_t long key, @In @u_int64_t int keySize);
+
+    int crypto_generichash_init(@In @caddr_t long state, @In @caddr_t long key, @In @u_int64_t int keySize, @In @u_int64_t int out);
+
+    int crypto_generichash_update(@In @caddr_t long state, @In @caddr_t long in, @In @u_int64_t long inlen);
+
+    int crypto_generichash_final(@In @caddr_t long state, @In @caddr_t long out, @In @u_int64_t long outlen);
 
     int crypto_hash_sha256(@In long buffer, @In long message, @In @u_int64_t int sizeof);
 

--- a/src/test/java/net/openhft/chronicle/salt/Blake2bTest.java
+++ b/src/test/java/net/openhft/chronicle/salt/Blake2bTest.java
@@ -1,0 +1,172 @@
+package net.openhft.chronicle.salt;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.bytes.internal.NativeBytesStore;
+import net.openhft.chronicle.core.OS;
+import org.junit.Test;
+
+import javax.xml.bind.DatatypeConverter;
+
+import static net.openhft.chronicle.salt.TestUtil.nativeBytesStore;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
+
+public class Blake2bTest {
+
+    // https://raw.githubusercontent.com/BLAKE2/BLAKE2/master/testvectors/blake2-kat.json for test vectors
+
+    private static void doTestBlake2b256(String inputStr, String expectedHex) {
+        doTestBlake2b256(inputStr.getBytes(), expectedHex);
+    }
+
+    private static void doTestBlake2b256(byte[] inputStr, String expectedHex) {
+        Bytes<?> input = Bytes.allocateElasticDirect();
+        input.write(inputStr);
+        Bytes<?> hashBlake = Bytes.allocateElasticDirect();
+        Blake2b.append256(hashBlake, input);
+        Bytes<?> expected = Bytes.allocateElasticDirect();
+        expected.write(DatatypeConverter.parseHexBinary(expectedHex));
+        assertEquals(expected.toHexString(), hashBlake.toHexString());
+        expected.releaseLast();
+        input.releaseLast();
+        hashBlake.releaseLast();
+    }
+
+    private static void doTestBlake2b512(byte[] inputStr, String expectedHex) {
+        Bytes<?> input = Bytes.allocateElasticDirect();
+        input.write(inputStr);
+        Bytes<?> hashBlake = Bytes.allocateElasticDirect();
+        Blake2b.append512(hashBlake, input);
+        Bytes<?> expected = Bytes.allocateElasticDirect();
+        expected.write(DatatypeConverter.parseHexBinary(expectedHex));
+        assertEquals(expected.toHexString(), hashBlake.toHexString());
+        expected.releaseLast();
+        input.releaseLast();
+        hashBlake.releaseLast();
+    }
+
+    @Test
+    public void testHash256() {
+        doTestBlake2b256(new byte[0], "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8");
+        doTestBlake2b256("abc".getBytes(), "bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319");
+        doTestBlake2b256(DatatypeConverter.parseHexBinary("de188941a3375d3a8a061e67576e926d"),
+                "ad998c6554e8233c3b87edf20053a233f13840a6c84069d00d2553f3c426323e");
+        doTestBlake2b256(
+                DatatypeConverter.parseHexBinary(
+                        "de188941a3375d3a8a061e67576e926dc71a7fa3f0cceb97452b4d3227965f9ea8cc75076d9fb9c5417aa5cb30fc22198b34982dbb629e"),
+                "4073644f3ddd85c44ccd932606c5280ea0557d08e716537031e689f860f8b012");
+
+        doTestBlake2b256("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+                "5f7a93da9c5621583f22e49e8e91a40cbba37536622235a380f434b9f68e49c4");
+        doTestBlake2b256("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+                "90a0bcf5e5a67ac1578c2754617994cfc248109275a809a0721feebd1e918738");
+        StringBuilder strOneMillionChara = new StringBuilder();
+        for (int i = 0; i < 1_000_000; i++) {
+            strOneMillionChara.append('a');
+        }
+        doTestBlake2b256(strOneMillionChara.toString(), "0741850f36cba4259628355d1073e24ddb9ca0e1bfac36fd39ae5dc2101e23a4");
+    }
+
+    @Test
+    public void testMultiPart256() {
+        assumeFalse(OS.isWindows());
+
+        Blake2b.MultiPart256 multi = new Blake2b.MultiPart256();
+        assertMultiPart256(multi, "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
+                NativeBytesStore.from(new byte[0]));
+
+        assertMultiPart256(multi, "03170A2E7597B7B7E3D84C05391D139A62B157E78786D8C082F29DCF4C111314",
+                NativeBytesStore.from(new byte[]{0}));
+
+        assertMultiPart256(multi, "117AD6B940F5E8292C007D9C7E7350CD33CF85B5887E8DA71C7957830F536E7C",
+                nativeBytesStore("abcdefgh"),
+                nativeBytesStore("ijklmnop"),
+                nativeBytesStore("qrstuvwxyz"));
+
+        // hypercore leaf batch example
+        assertMultiPart256(multi, "CCFA4259EE7C41E411E5770973A49C5CEFFB5272D6A37F2C6F2DAC2190F7E2B7",
+                NativeBytesStore.from(new byte[]{0}),                        // leafy type
+                NativeBytesStore.from(new byte[]{0, 0, 0, 0, 0, 0, 0, 11}),  // message length
+                nativeBytesStore("hello world"));                       // message
+
+        assertMultiPart256(multi, "BAB07BD8DB18F6431170DF84DCFED749D7FA9EAC9E2C6BFE346F26453A65EAFC",
+                NativeBytesStore.from(new byte[]{0}),                        // leafy type
+                NativeBytesStore.from(new byte[]{0, 0, 0, 0, 0, 0, 0, 11}),  // message length
+                nativeBytesStore("world hello"));                       // message
+    }
+
+    @Test
+    public void testHash512() {
+        assumeFalse(OS.isWindows());
+
+        doTestBlake2b512(new byte[0], "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce");
+        doTestBlake2b512("abc".getBytes(), "ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d17d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923");
+        doTestBlake2b512(DatatypeConverter.parseHexBinary("000102030405060708090a0b0c0d0e0f10"),
+                "9c4d0c3e1cdbbf485bec86f41cec7c98373f0e09f392849aaa229ebfbf397b22085529cb7ef39f9c7c2222a514182b1effaa178cc3687b1b2b6cbcb6fdeb96f8");
+        doTestBlake2b512(DatatypeConverter.parseHexBinary(
+                        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b" +
+                                "2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b"),
+                "3c9a7359ab4febce07b20ac447b06a240b7fe1dae5439c49b60b5819f7812e4c172406c1aac316713cf0dded1038077258e2eff5b33913d9d95caeb4e6c6b970");
+
+        doTestBlake2b512(DatatypeConverter.parseHexBinary(
+                        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f" +
+                                "303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f" +
+                                "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f" +
+                                "909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf" +
+                                "c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeef" +
+                                "f0f1f2f3f4f5f6f7f8f9fafbfcfdfe"),
+                "5b21c5fd8868367612474fa2e70e9cfa2201ffeee8fafab5797ad58fefa17c9b5b107da4a3db6320baaf2c8617d5a51df914ae88da3867c2d41f0cc14fa67928");
+        StringBuilder strOneMillionChara = new StringBuilder();
+        for (int i = 0; i < 1_000_000; i++) {
+            strOneMillionChara.append('a');
+        }
+        doTestBlake2b512(strOneMillionChara.toString().getBytes(), "98fb3efb7206fd19ebf69b6f312cf7b64e3b94dbe1a17107913975a793f177e1d077609d7fba363cbba00d05f7aa4e4fa8715d6428104c0a75643b0ff3fd3eaf");
+    }
+
+    @Test
+    public void testMultiPart512() {
+        assumeFalse(OS.isWindows());
+
+        Blake2b.MultiPart512 multi = new Blake2b.MultiPart512();
+
+        assertMultiPart512(multi, "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce",
+                NativeBytesStore.from(new byte[0]));
+
+        assertMultiPart512(multi, "2FA3F686DF876995167E7C2E5D74C4C7B6E48F8068FE0E44208344D480F7904C36963E44115FE3EB2A3AC8694C28BCB4F5A0F3276F2E79487D8219057A506E4B",
+                NativeBytesStore.from(new byte[]{0}));
+
+        assertMultiPart512(multi,
+                "C68EDE143E416EB7B4AAAE0D8E48E55DD529EAFED10B1DF1A61416953A2B0A5666C761E7D412E6709E31FFE221B7A7A73908CB95A4D120B8B090A87D1FBEDB4C",
+                nativeBytesStore("abcdefgh"),
+                nativeBytesStore("ijklmnop"),
+                nativeBytesStore("qrstuvwxyz"));
+
+        // hypercore leaf batch example
+        assertMultiPart512(multi, "E623E28724C7815EB82FAE2F32A186EB6B70C3DA63B721D7B16094EB0DE6FF29969079BAC8F7DEA85CFCB24226775BAAEC2FE27F09B55BA477FEED41DEE36712",
+                NativeBytesStore.from(new byte[]{0}),                        // leafy type
+                NativeBytesStore.from(new byte[]{0, 0, 0, 0, 0, 0, 0, 11}),  // message length
+                nativeBytesStore("hello world"));                           // message
+
+        assertMultiPart512(multi, "0B0595CB66B3E920FFF80F33441FF7A2CE3E269B7B4DCBF24065B87AEA43B31D5763EFD62E512F416D931C6904C852D403F23738DD33F72062EA209FA0265A49",
+                NativeBytesStore.from(new byte[]{0}),                        // leafy type
+                NativeBytesStore.from(new byte[]{0, 0, 0, 0, 0, 0, 0, 11}),  // message length
+                nativeBytesStore("world hello"));                           // message
+    }
+
+    private void assertMultiPart256(Blake2b.MultiPart256 multi, String expectedHex, BytesStore... messages) {
+        for (BytesStore message : messages) {
+            multi.add(message);
+        }
+        assertEquals(expectedHex.toUpperCase(), DatatypeConverter.printHexBinary(multi.hash().toByteArray()));
+        multi.reset();
+    }
+
+    private void assertMultiPart512(Blake2b.MultiPart512 multi, String expectedHex, BytesStore... messages) {
+        for (BytesStore message : messages) {
+            multi.add(message);
+        }
+        assertEquals(expectedHex.toUpperCase(), DatatypeConverter.printHexBinary(multi.hash().toByteArray()));
+        multi.reset();
+    }
+}


### PR DESCRIPTION
Exposes Sodium's generic hash (Blake2b) and provides 256 and 512 bit variants in a similar fashion to the existing SHA2 class 