### PR TITLE
Add /opt/homebrew/lib to the list of possible libsodium locations.

### DIFF
--- a/src/main/java/net/openhft/chronicle/salt/Sodium.java
+++ b/src/main/java/net/openhft/chronicle/salt/Sodium.java
@@ -172,7 +172,7 @@ public interface Sodium {
 
             Sodium sodium = null;
             try {
-                sodium = LibraryLoader.create(Sodium.class).search("lib").search("/usr/local/lib").search("/opt/local/lib").load(libraryName);
+                sodium = LibraryLoader.create(Sodium.class).search("lib").search("/usr/local/lib").search("/opt/local/lib").search("/opt/homebrew/lib").load(libraryName);
 
             } catch (Error e) {
                 if (Platform.getNativePlatform().getOS() == Platform.OS.WINDOWS)


### PR DESCRIPTION
Fixes #27.