### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/src/main/java/net/openhft/chronicle/salt/Blake2b.java
+++ b/src/main/java/net/openhft/chronicle/salt/Blake2b.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/salt/Bridge.java
+++ b/src/main/java/net/openhft/chronicle/salt/Bridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/salt/EasyBox.java
+++ b/src/main/java/net/openhft/chronicle/salt/EasyBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/salt/Ed25519.java
+++ b/src/main/java/net/openhft/chronicle/salt/Ed25519.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/salt/SHA2.java
+++ b/src/main/java/net/openhft/chronicle/salt/SHA2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/salt/SealedBox.java
+++ b/src/main/java/net/openhft/chronicle/salt/SealedBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/salt/Signature.java
+++ b/src/main/java/net/openhft/chronicle/salt/Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/salt/Sodium.java
+++ b/src/main/java/net/openhft/chronicle/salt/Sodium.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/salt/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/salt/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/BatchSha256Rc4Test.java
+++ b/src/test/java/net/openhft/chronicle/salt/BatchSha256Rc4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/BatchSha256Sha512RandomTest.java
+++ b/src/test/java/net/openhft/chronicle/salt/BatchSha256Sha512RandomTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/BatchSignAndVerifyEd25519Test.java
+++ b/src/test/java/net/openhft/chronicle/salt/BatchSignAndVerifyEd25519Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/Blake2bTest.java
+++ b/src/test/java/net/openhft/chronicle/salt/Blake2bTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/BytesForTesting.java
+++ b/src/test/java/net/openhft/chronicle/salt/BytesForTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/EasyBoxTest.java
+++ b/src/test/java/net/openhft/chronicle/salt/EasyBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/Ed25519Test.java
+++ b/src/test/java/net/openhft/chronicle/salt/Ed25519Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/GeneratePublicKeyPerfMain.java
+++ b/src/test/java/net/openhft/chronicle/salt/GeneratePublicKeyPerfMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/InvalidBase32Test.java
+++ b/src/test/java/net/openhft/chronicle/salt/InvalidBase32Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/Rc4Cipher.java
+++ b/src/test/java/net/openhft/chronicle/salt/Rc4Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/SHA256PerfMain.java
+++ b/src/test/java/net/openhft/chronicle/salt/SHA256PerfMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/SHA2Test.java
+++ b/src/test/java/net/openhft/chronicle/salt/SHA2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/SHA512PerfMain.java
+++ b/src/test/java/net/openhft/chronicle/salt/SHA512PerfMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/SealedBoxTest.java
+++ b/src/test/java/net/openhft/chronicle/salt/SealedBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/SignAndVerifyPerfMain.java
+++ b/src/test/java/net/openhft/chronicle/salt/SignAndVerifyPerfMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/SignatureTest.java
+++ b/src/test/java/net/openhft/chronicle/salt/SignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/SodiumTest.java
+++ b/src/test/java/net/openhft/chronicle/salt/SodiumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/salt/TestUtil.java
+++ b/src/test/java/net/openhft/chronicle/salt/TestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  *       https://chronicle.software
  *


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, "Chronicle Map Contributors", etc.) are intentionally left alone.
- Mechanical change, no code behaviour affected.

## Test plan
- [ ] Visual diff review - expect only `5` -> `6` on the end year.
- [ ] CI green (no logic changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)