### PR TITLE
docs: replace retired maven-badges.herokuapp.com and dead search.maven.org URLs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,8 +2,8 @@
 
 see also https://en.wikipedia.org/wiki/NaCl_(software)
 
-[caption="", link=https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-salt]
-image::https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-salt/badge.svg[]
+[caption="", link=https://central.sonatype.com/artifact/net.openhft/chronicle-salt]
+image::https://img.shields.io/maven-central/v/net.openhft/chronicle-salt.svg[]
 image:https://javadoc.io/badge2/net.openhft/chronicle-salt/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/chronicle-salt/latest/index.html"]
 
 This library natively supports Chronicle Bytes and can sign and verify data entirely off heap. This saves copying data to/from byte[] (not creating them)


### PR DESCRIPTION
## Summary
- **Heroku retired free tier** so `maven-badges.herokuapp.com` is unreliable. Badges now point at `img.shields.io/maven-central/v/<group>/<artifact>.svg`.
- Badge/artifact links point at `central.sonatype.com/artifact/<group>/<artifact>` (the canonical Maven Central artifact page).
- Dead/clunky `search.maven.org/#search?g=...&a=...` URLs collapse to the same `central.sonatype.com/artifact/<g>/<a>` page.

## Test plan
- [ ] Click the Maven Central badge - should load a version.
- [ ] Click the artifact link - should land on Sonatype Central.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)