### PR TITLE
docs: update stale GitHub branch references (master -> develop/ea)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -905,7 +905,7 @@ You need to run `mvn install` to build `libbridge` first.
 
 == Key Terms
 
-Chronicle Bytes :: A similar purpose to Java NIO’s ByteBuffer, but with added extenstions.        https://github.com/OpenHFT/Chronicle-Bytes/blob/master/README.adoc[View Chronicle-Bytes here]
+Chronicle Bytes :: A similar purpose to Java NIO’s ByteBuffer, but with added extenstions.        https://github.com/OpenHFT/Chronicle-Bytes/blob/ea/README.adoc[View Chronicle-Bytes here]
  
 Cryptography :: The practice of hiding information using a mix of mathematics, computer science and electrical engineering.
 


### PR DESCRIPTION
## Summary
- Own-repo and OpenHFT repos that default to `develop` now use `/blob/develop/` and `/tree/develop/`.
- Chronicle-Bytes references move to `/blob/ea/` (its default branch).
- OpenHFT/RFC references remain on `master` (still its default).

## Test plan
- [ ] Clicking the updated links lands on a valid file/tree page.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)