### PR TITLE
docs: fix subject-verb agreement in internal package-info

### DIFF
--- a/src/main/java/net/openhft/chronicle/salt/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/salt/internal/package-info.java
@@ -17,7 +17,7 @@
  */
 
 /**
- * This package and any and all sub-packages contains strictly internal classes for this Chronicle library. Internal classes shall
+ * This package and any and all sub-packages contain strictly internal classes for this Chronicle library. Internal classes shall
  * <em>never</em> be used directly.
  * <p>
  * Specifically, the following actions (including, but not limited to) are not allowed on internal classes and packages:


### PR DESCRIPTION
## Summary
Plural subject "any and all sub-packages" was paired with singular verb "contains". Changed to "contain".

Javadoc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)