### PR TITLE
docs: fix three malformed javadoc comments

### DIFF
--- a/src/main/java/net/openhft/chronicle/salt/EasyBox.java
+++ b/src/main/java/net/openhft/chronicle/salt/EasyBox.java
@@ -331,11 +331,11 @@ public enum EasyBox {
         }
 
         /**
-         * /** Generate deterministic nonce from simple long id (which only uses 8 out of 32 seed bytes) Optionally pass in the underlying
+         * Generate deterministic nonce from simple long id (which only uses 8 out of 32 seed bytes) Optionally pass in the underlying
          * BytesStore, else one is created
          *
          * @param id
-         *            - the seed value (2^64 options_
+         *            - the seed value (2^64 options)
          * @return - a deterministic nonce
          */
         public static Nonce deterministic(long id) {

--- a/src/main/java/net/openhft/chronicle/salt/SHA2.java
+++ b/src/main/java/net/openhft/chronicle/salt/SHA2.java
@@ -77,7 +77,7 @@ public enum SHA2 {
      *
      * @param message
      *            - the message to hash
-     * @return - the sha256 hash
+     * @return - the sha512 hash
      */
     public static BytesStore sha512(BytesStore message) {
         return sha512(null, message);


### PR DESCRIPTION
## Summary
- `EasyBox.deterministic(long)`: removes a stray nested `/**` inside an already-open javadoc block, and closes the dangling `(2^64 options` annotation (was `options_`).
- `SHA2.sha512(BytesStore)`: `@return` previously said "sha256 hash". The method hashes with SHA-512; corrected to "sha512 hash".

Javadoc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)