### PR TITLE
docs: fix invalid README code examples (hashing section)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -630,7 +630,7 @@ void SHA2.appendSha256( Bytes<?> output, BytesStore message );
 For example:
 [source, Java]
 ----
-    BytesStore message = "example message";
+    BytesStore message = Bytes.from("example message");
 
     // Option 1: Create and return the BytesStore
     BytesStore hash = SHA2.sha256( message );
@@ -640,7 +640,7 @@ For example:
     SHA2.sha256( hash, message );
 
     // Option 3: append the hash to a given Bytes handle
-    Bytes<?> hash256 = Bytes.allocateDirect(SHA2.HASH_SHA256_BYTES));
+    Bytes<?> hash256 = Bytes.allocateDirect(SHA2.HASH_SHA256_BYTES);
     SHA2.appendSha256(hash256, message);
 ----
 
@@ -660,7 +660,7 @@ void SHA2.appendSha512( Bytes<?> output, BytesStore message );
 For example:
 [source, Java]
 ----
-    BytesStore message = "example message";
+    BytesStore message = Bytes.from("example message");
 
     // Option 1: Create and return the BytesStore
     BytesStore hash = SHA2.sha512( message );
@@ -670,7 +670,7 @@ For example:
     SHA2.sha512( hash, message );
 
     // Option 3: append the hash to a given Bytes handle
-    Bytes<?> hash512 = Bytes.allocateDirect(SHA2.HASH_SHA512_BYTES));
+    Bytes<?> hash512 = Bytes.allocateDirect(SHA2.HASH_SHA512_BYTES);
     SHA2.appendSha512(hash512, message);
 ----
 
@@ -765,7 +765,7 @@ void Blake2b.append256( Bytes<?> output, BytesStore message );
 For example:
 [source, Java]
 ----
-    BytesStore message = "example message";
+    BytesStore message = Bytes.from("example message");
 
     // Option 1: Create and return the BytesStore
     BytesStore hash = Blake2b.hash256( message );
@@ -775,7 +775,7 @@ For example:
     Blake2b.hash256( hash, message );
 
     // Option 3: append the hash to a given Bytes handle
-    Bytes<?> hash256 = Bytes.allocateDirect(Blake2b.HASH_BLAKE2B_256_BYTES));
+    Bytes<?> hash256 = Bytes.allocateDirect(Blake2b.HASH_BLAKE2B_256_BYTES);
     Blake2b.append256(hash256, message);
 ----
 
@@ -795,7 +795,7 @@ void Blake2b.append512( Bytes<?> output, BytesStore message );
 For example:
 [source, Java]
 ----
-    BytesStore message = "example message";
+    BytesStore message = Bytes.from("example message");
 
     // Option 1: Create and return the BytesStore
     BytesStore hash = Blake2b.hash512( message );
@@ -805,7 +805,7 @@ For example:
     Blake2b.hash512( hash, message );
 
     // Option 3: append the hash to a given Bytes handle
-    Bytes<?> hash512 = Bytes.allocateDirect(Blake2b.HASH_BLAKE2B_512_BYTES));
+    Bytes<?> hash512 = Bytes.allocateDirect(Blake2b.HASH_BLAKE2B_512_BYTES);
     Blake2b.append512(hash512, message);
 ----
 


### PR DESCRIPTION
## Summary
- `BytesStore` is an interface; `BytesStore message = \"example message\";` does not compile. Switched to `Bytes.from(\"example message\")` (Bytes implements BytesStore), so the snippet is copy-paste valid.
- Removed a stray trailing `)` in the `Bytes.allocateDirect(HASH_...BYTES)` calls in the SHA-256, SHA-512, Blake2b-256 and Blake2b-512 examples.

Documentation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)